### PR TITLE
Loading the data now with tfio for most of what we can

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ h5py
 ismrmrd
 numpy
 tensorflow>=2.2
+tensorflow-io>=1.5.0
 tfkbnufft

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ h5py
 ismrmrd
 numpy
 tensorflow>=2.2
-tensorflow-io>=1.5.0
+tensorflow-io>=0.15.0
 tfkbnufft

--- a/tf_fastmri_data/dataset_builder.py
+++ b/tf_fastmri_data/dataset_builder.py
@@ -56,6 +56,8 @@ class FastMRIDatasetBuilder:
         self.batch_size = batch_size
         if self.batch_size is not None and not self.slice_random:
             raise ValueError('You can only use batching when selecting one slice')
+        if self.slice_random and self.batch_size is None:
+            self.batch_size = 1
         self._files = sorted(self.path.glob('*.h5'))
         self.filtered_files = [
             f for f in self._files

--- a/tf_fastmri_data/dataset_builder.py
+++ b/tf_fastmri_data/dataset_builder.py
@@ -155,27 +155,6 @@ class FastMRIDatasetBuilder:
     def preprocessing(self, *data_tensors):
         raise NotImplementedError('You must implement a preprocessing function')
 
-    def _set_tensor_shapes(self, *data_tensors):
-        if self.mode == 'train':
-            kspace, image, contrast = data_tensors
-        elif self.mode == 'test':
-            kspace, mask, contrast, af, output_shape = data_tensors
-        kspace_size = [None] * 2
-        if not self.slice_random:
-            kspace_size.append(None)
-        if self.multicoil:
-            kspace_size.append(None)
-        kspace.set_shape(kspace_size)
-        if self.mode == 'train':
-            image_size = [None] * 2
-            if not self.slice_random:
-                image_size.append(None)
-            image.set_shape(image_size)
-            return kspace, image, contrast
-        elif self.mode == 'test':
-            mask.set_shape([None])
-            return kspace, mask, contrast, af, output_shape
-
     def pad_crop_kspace(self, *data_tensors):
         kspace, *others = data_tensors
         # NOTE: for now only doing it for the last dimension

--- a/tf_fastmri_data/dataset_builder.py
+++ b/tf_fastmri_data/dataset_builder.py
@@ -61,6 +61,12 @@ class FastMRIDatasetBuilder:
             f for f in self._files
             if self.filter_condition(*load_metadata_from_file(f))
         ]
+        if not self.filtered_files:
+            raise ValueError(
+                f'''No files for this contrast ({self.contrast}) and
+                acceleration factor ({self.accel_factor})
+                found at this path {self.path}'''
+            )
         self.files_ds = tf.data.Dataset.from_tensor_slices(
             [str(f) for f in self.filtered_files],
         )

--- a/tf_fastmri_data/dataset_builder.py
+++ b/tf_fastmri_data/dataset_builder.py
@@ -109,7 +109,7 @@ class FastMRIDatasetBuilder:
             # you can only ask complex image if you ask for kspace
             # for now also available only for knee images (320 x 320)
             self._raw_ds = self._raw_ds.map(
-                lambda _, kspace: crop(ortho_ifft2d(kspace), 320)
+                lambda _, kspace: crop(ortho_ifft2d(kspace), (320, 320))
             )
         if self.brain:
             output_shape_ds = tf.data.Dataset.from_tensor_slices(

--- a/tf_fastmri_data/dataset_builder.py
+++ b/tf_fastmri_data/dataset_builder.py
@@ -66,7 +66,9 @@ class FastMRIDatasetBuilder:
             f for f in self._files
             if self.filter_condition(*load_metadata_from_file(f))
         ]
-        self.files_ds = tf.data.Dataset.from_tensor_slices(self.filtered_files)
+        self.files_ds = tf.data.Dataset.from_tensor_slices(
+            [str(f) for f in self.filtered_files],
+        )
         if self.shuffle:
             self.files_ds = self.files_ds.shuffle(
                 buffer_size=1000,
@@ -107,8 +109,8 @@ class FastMRIDatasetBuilder:
             #         self.pad_crop_kspace,
             #         num_parallel_calls=self.num_parallel_calls,
             #     )
-            self._filtered_ds = self._filtered_ds.batch(self.batch_size)
-        self._preprocessed_ds = self._filtered_ds.map(
+            self._raw_ds = self._raw_ds.batch(self.batch_size)
+        self._preprocessed_ds = self._raw_ds.map(
             self.preprocessing,
             num_parallel_calls=self.num_parallel_calls,
         )

--- a/tf_fastmri_data/datasets/cartesian.py
+++ b/tf_fastmri_data/datasets/cartesian.py
@@ -22,7 +22,7 @@ class CartesianFastMRIDatasetBuilder(FastMRIDatasetBuilder):
         if self.dataset in ['train', 'val']:
             kwargs.update(prefetch=True)
         elif self.dataset in ['test']:
-            if tfio.__version__ <= (1, 5, 0):
+            if tfio.__versioninfo__ <= (1, 5, 0):
                 raise ValueError(
                     '''Test cartesian dataset is not available for
                     tfio under 1.5.0 because it cannot handle boolean data,

--- a/tf_fastmri_data/datasets/cartesian.py
+++ b/tf_fastmri_data/datasets/cartesian.py
@@ -61,10 +61,6 @@ class CartesianFastMRIDatasetBuilder(FastMRIDatasetBuilder):
         return mask
 
     def _preprocessing_train(self, image, kspace, output_shape=None):
-        if self.kspace_size[0] < 640 or (self.same_size_kspace and self.batch_size is not None):
-            image = ortho_ifft2d(kspace)
-            # TODO: handle multicoil here potentially
-            image = tf.abs(image)
         mask = self.gen_mask(kspace)
         kspace = tf.cast(mask, kspace.dtype) * kspace
         kspace, image = scale_tensors(kspace, image, scale_factor=self.scale_factor)

--- a/tf_fastmri_data/datasets/cartesian.py
+++ b/tf_fastmri_data/datasets/cartesian.py
@@ -22,7 +22,7 @@ class CartesianFastMRIDatasetBuilder(FastMRIDatasetBuilder):
         if self.dataset in ['train', 'val']:
             kwargs.update(prefetch=True)
         elif self.dataset in ['test']:
-            if tfio.__version__ < (1, 5, 0):
+            if tfio.__version__ <= (1, 5, 0):
                 raise ValueError(
                     '''Test cartesian dataset is not available for
                     tfio under 1.5.0 because it cannot handle boolean data,

--- a/tf_fastmri_data/datasets/cartesian.py
+++ b/tf_fastmri_data/datasets/cartesian.py
@@ -22,7 +22,7 @@ class CartesianFastMRIDatasetBuilder(FastMRIDatasetBuilder):
         if self.dataset in ['train', 'val']:
             kwargs.update(prefetch=True)
         elif self.dataset in ['test']:
-            if tfio.__versioninfo__ <= (1, 5, 0):
+            if tuple(int(v) for v in tfio.__version__.split('.')) <= (1, 5, 0):
                 raise ValueError(
                     '''Test cartesian dataset is not available for
                     tfio under 1.5.0 because it cannot handle boolean data,

--- a/tf_fastmri_data/datasets/cartesian.py
+++ b/tf_fastmri_data/datasets/cartesian.py
@@ -22,7 +22,7 @@ class CartesianFastMRIDatasetBuilder(FastMRIDatasetBuilder):
         if self.dataset in ['train', 'val']:
             kwargs.update(prefetch=True)
         elif self.dataset in ['test']:
-            if tuple(int(v) for v in tfio.__version__.split('.')) <= (1, 5, 0):
+            if tuple(int(v) for v in tfio.__version__.split('.')) <= (0, 15, 0):
                 raise ValueError(
                     '''Test cartesian dataset is not available for
                     tfio under 1.5.0 because it cannot handle boolean data,

--- a/tf_fastmri_data/datasets/cartesian.py
+++ b/tf_fastmri_data/datasets/cartesian.py
@@ -1,4 +1,5 @@
 import tensorflow as tf
+import tensorflow_io as tfio
 
 from tf_fastmri_data.dataset_builder import FastMRIDatasetBuilder
 from tf_fastmri_data.preprocessing_utils.extract_smaps import extract_smaps
@@ -21,6 +22,12 @@ class CartesianFastMRIDatasetBuilder(FastMRIDatasetBuilder):
         if self.dataset in ['train', 'val']:
             kwargs.update(prefetch=True)
         elif self.dataset in ['test']:
+            if tfio.__version__ < (1, 5, 0):
+                raise ValueError(
+                    '''Test cartesian dataset is not available for
+                    tfio under 1.5.0 because it cannot handle boolean data,
+                    see https://github.com/tensorflow/io/issues/1144'''
+                )
             kwargs.update(repeat=False, prefetch=False)
         self.brain = brain
         if mask_mode is None:

--- a/tf_fastmri_data/datasets/cartesian.py
+++ b/tf_fastmri_data/datasets/cartesian.py
@@ -60,7 +60,7 @@ class CartesianFastMRIDatasetBuilder(FastMRIDatasetBuilder):
         )
         return mask
 
-    def _preprocessing_train(self, kspace, image, _contrast):
+    def _preprocessing_train(self, image, kspace, output_shape=None):
         if self.kspace_size[0] < 640 or (self.same_size_kspace and self.batch_size is not None):
             image = ortho_ifft2d(kspace)
             # TODO: handle multicoil here potentially
@@ -80,7 +80,7 @@ class CartesianFastMRIDatasetBuilder(FastMRIDatasetBuilder):
             model_inputs += (output_shape,)
         return model_inputs, image
 
-    def _preprocessing_test(self, kspace, mask, _contrast, _af, output_shape):
+    def _preprocessing_test(self, mask, kspace, output_shape=None):
         (kspace,) = scale_tensors(kspace, scale_factor=self.scale_factor)
         kspace = kspace[..., None]
         mask = mask_reshaping_and_casting(mask, tf.shape(kspace[..., 0]), multicoil=self.multicoil)

--- a/tf_fastmri_data/datasets/noisy.py
+++ b/tf_fastmri_data/datasets/noisy.py
@@ -96,15 +96,15 @@ class ComplexNoisyFastMRIDatasetBuilder(NoisyFastMRIDatasetBuilder):
         orig_prebuild = kwargs.get('prebuild', True)
         kwargs.update(dict(prebuild=False))
         super(ComplexNoisyFastMRIDatasetBuilder, self).__init__(
+            complex_image=True,
             **kwargs,
         )
         self.no_kspace = False
         if orig_prebuild:
             self._build_datasets()
 
-    def _preprocessing_train(self, _image, kspace):
-        kspace = scale_tensors(kspace, scale_factor=self.scale_factor)[0]
-        image = ortho_ifft2d(kspace)
+    def _preprocessing_train(self, image):
+        image = scale_tensors(image, scale_factor=self.scale_factor)[0]
         image = image[..., None]
         noise_power = self.draw_noise_power(batch_size=tf.shape(image)[0])
         normal_noise = tf.random.normal(

--- a/tf_fastmri_data/datasets/noisy.py
+++ b/tf_fastmri_data/datasets/noisy.py
@@ -31,7 +31,7 @@ class NoisyFastMRIDatasetBuilder(FastMRIDatasetBuilder):
         if self.mode == 'test':
             raise NotImplementedError('Noisy dataset only works for train/val')
 
-    def _preprocessing_train(self, _kspace, image, _contrast):
+    def _preprocessing_train(self, image):
         image = image[..., None]
         if self.image_size != 320:
             image = tf.image.resize(image, [self.image_size, self.image_size])
@@ -102,7 +102,7 @@ class ComplexNoisyFastMRIDatasetBuilder(NoisyFastMRIDatasetBuilder):
         if orig_prebuild:
             self._build_datasets()
 
-    def _preprocessing_train(self, kspace, _image, _contrast):
+    def _preprocessing_train(self, _image, kspace):
         kspace = scale_tensors(kspace, scale_factor=self.scale_factor)[0]
         image = ortho_ifft2d(kspace)
         image = image[..., None]

--- a/tf_fastmri_data/datasets/non_cartesian.py
+++ b/tf_fastmri_data/datasets/non_cartesian.py
@@ -66,7 +66,7 @@ class NonCartesianFastMRIDatasetBuilder(FastMRIDatasetBuilder):
             traj = get_spiral_trajectory(self.image_size, af=self.af)
         return traj
 
-    def preprocessing(self, kspace, image, _contrast):
+    def preprocessing(self, image, kspace):
         traj = self.generate_trajectory()
         interpob = self.nfft_obj._extract_nufft_interpob()
         nufftob_forw = kbnufft_forward(interpob)

--- a/tf_fastmri_data/h5.py
+++ b/tf_fastmri_data/h5.py
@@ -1,5 +1,3 @@
-import random
-
 import h5py
 import ismrmrd
 import tensorflow as tf

--- a/tf_fastmri_data/h5.py
+++ b/tf_fastmri_data/h5.py
@@ -12,6 +12,9 @@ def load_data_from_file(fpath, slice_random=False, no_kspace=False, multicoil=Fa
         image_name = '/reconstruction_esc'
         kspace_shape = tuple([None]*3)
     image_shape = tuple([None]*3)
+    if slice_random:
+        kspace_shape = kspace_shape[1:]
+        image_shape = image_shape[1:]
     mask_shape = (None,)
     kspace_name = '/kspace'
     mask_name = '/mask'
@@ -47,6 +50,8 @@ def load_data_from_file(fpath, slice_random=False, no_kspace=False, multicoil=Fa
         slices = (0, n_slices)
     if mode == 'train':
         image = h5_tensors(image_name)[slices[0]:slices[1]]
+        if slice_random:
+            image = tf.squeeze(image, axis=0)
         image.set_shape(image_shape)
         outputs = [image]
     else:
@@ -55,6 +60,8 @@ def load_data_from_file(fpath, slice_random=False, no_kspace=False, multicoil=Fa
         outputs = [mask]
     if not no_kspace:
         kspace = h5_tensors(kspace_name)[slices[0]:slices[1]]
+        if slice_random:
+            kspace = tf.squeeze(kspace, axis=0)
         kspace.set_shape(kspace_shape)
         outputs.append(kspace)
     return outputs

--- a/tf_fastmri_data/h5.py
+++ b/tf_fastmri_data/h5.py
@@ -50,7 +50,7 @@ def load_data_from_file(fpath, slice_random=False, no_kspace=False, multicoil=Fa
         image.set_shape(image_shape)
         outputs = [image]
     else:
-        mask = h5_tensors(mask_name)
+        mask = h5_tensors(mask_name)[:]
         mask.set_shape(mask_shape)
         outputs = [mask]
     if not no_kspace:

--- a/tf_fastmri_data/h5.py
+++ b/tf_fastmri_data/h5.py
@@ -2,57 +2,76 @@ import random
 
 import h5py
 import ismrmrd
+import tensorflow as tf
+import tensorflow_io as tfio
 
 
-def load_data_from_file(filename, slice_random=False, no_kspace=False, kspace_size=None):
+def load_data_from_file(fpath, slice_random=False, no_kspace=False, multicoil=False, mode='train'):
+    if multicoil:
+        image_name = '/reconstruction_rss'
+        kspace_shape = tuple([None]*4)
+    else:
+        image_name = '/reconstruction_esc'
+        kspace_shape = tuple([None]*3)
+    image_shape = tuple([None]*3)
+    mask_shape = (None,)
+    kspace_name = '/kspace'
+    mask_name = '/mask'
+    spec = {}
+    if mode == 'train':
+        spec.update({
+            image_name: tf.TensorSpec(shape=image_shape, dtype=tf.float32),
+        })
+    else:
+        spec.update({
+            mask_name: tf.TensorSpec(shape=mask_shape, dtype=tf.bool),
+        })
+    if not no_kspace:
+        spec.update({
+            kspace_name: tf.TensorSpec(shape=kspace_shape, dtype=tf.complex64),
+        })
+    h5_tensors = tfio.IOTensor.from_hdf5(fpath, spec=spec)
+    if no_kspace:
+        main_tensor = image_name
+    else:
+        main_tensor = kspace_name
+    h5_main = h5_tensors(main_tensor)
+    n_slices = h5_main.shape[0]
+    if slice_random:
+        i_slice = tf.random.uniform(
+            shape=(),
+            minval=0,
+            maxval=n_slices,
+            dtype=tf.int64,
+        )
+        slices = (i_slice, i_slice + 1)
+    else:
+        slices = (0, n_slices)
+    if mode == 'train':
+        image = h5_tensors(image_name)[slices[0]:slices[1]]
+        image.set_shape(image_shape)
+        outputs = [image]
+    else:
+        mask = h5_tensors(mask_name)
+        mask.set_shape(mask_shape)
+        outputs = [mask]
+    if not no_kspace:
+        kspace = h5_tensors(kspace_name)[slices[0]:slices[1]]
+        kspace.set_shape(kspace_shape)
+        outputs.append(kspace)
+    return outputs
+
+def load_metadata_from_file(filename):
     with h5py.File(filename, 'r') as h5_obj:
-        if no_kspace:
-            kspace = None
-            crop_phase = None
-        else:
-            kspace = h5_obj['kspace']
-            shape = kspace.shape
-            if kspace_size is not None and kspace_size[0] < shape[-2]:
-                crop_phase = shape[-2] - kspace_size[0]
-            else:
-                crop_phase = None
-        if 'reconstruction_esc' in h5_obj.keys():
-            image = h5_obj['reconstruction_esc']
-        elif 'reconstruction_rss' in h5_obj.keys():
-            image = h5_obj['reconstruction_rss']
-        else:
-            image = None
-        if slice_random:
-            kspace, image = _slice_selection(kspace, image, crop_phase=crop_phase)
-        else:
-            if kspace is not None:
-                kspace = kspace[()]
-            if image is not None:
-                image = image[()]
-        mask = h5_obj.get('mask', None)
-        if mask is not None:
-            mask = mask[()].astype('bool')
-        ismrmrd_header = h5_obj['ismrmrd_header'][()]
-        output_shape = _get_output_shape(ismrmrd_header)
         contrast = h5_obj.attrs['acquisition']
         acceleration_factor = h5_obj.attrs.get('acceleration')
-        return kspace, image, mask, contrast, acceleration_factor, output_shape
+        return contrast, acceleration_factor
 
-def _slice_selection(kspace, image, crop_phase=None):
-    if kspace is not None:
-        base_tensor = kspace
-    else:
-        base_tensor = image
-    i_max = base_tensor.shape[0] - 1
-    i_slice = random.randint(0, i_max)
-    if kspace is not None:
-        if crop_phase is not None:
-            kspace = kspace[i_slice, crop_phase//2:-crop_phase//2]
-        else:
-            kspace = kspace[i_slice]
-    if image is not None:
-        image = image[i_slice]
-    return kspace, image
+def load_output_shape_from_file(filename):
+    with h5py.File(filename, 'r') as h5_obj:
+        ismrmrd_header = h5_obj['ismrmrd_header'][()]
+        output_shape = _get_output_shape(ismrmrd_header)
+        return output_shape
 
 def _get_output_shape(ismrmrd_header):
     hdr = ismrmrd.xsd.CreateFromDocument(ismrmrd_header)

--- a/tf_fastmri_data/preprocessing_utils/size_adjustment.py
+++ b/tf_fastmri_data/preprocessing_utils/size_adjustment.py
@@ -13,7 +13,7 @@ def pad(x, size):
 
 
 def crop(x, size):
-    shape = tf.shape(x)[-1]
-    to_crop = shape - size[-1]
-    cropped_x = x[..., to_crop//2:-to_crop//2]
+    shape = tf.shape(x)[-2:]
+    to_crop = shape - size
+    cropped_x = x[..., to_crop[0]//2:-to_crop[0]//2, to_crop[1]//2:-to_crop[1]//2]
     return cropped_x

--- a/tf_fastmri_data/tests/datasets/cartesian_test.py
+++ b/tf_fastmri_data/tests/datasets/cartesian_test.py
@@ -1,5 +1,8 @@
+from contextlib import ExitStack
+
 import numpy as np
 import pytest
+import tensorflow_io as tfio
 
 from tf_fastmri_data.datasets.cartesian import CartesianFastMRIDatasetBuilder
 
@@ -41,15 +44,20 @@ def test_cartesian_dataset_test(create_full_fastmri_test_tmp_dataset, mask_mode,
         path = create_full_fastmri_test_tmp_dataset['fastmri_tmp_multicoil_test']
     else:
         path = create_full_fastmri_test_tmp_dataset['fastmri_tmp_singlecoil_test']
-    ds = CartesianFastMRIDatasetBuilder(
-        dataset='test',
-        path=path,
-        mask_mode=mask_mode,
-        output_shape_spec=output_shape_spec,
-        brain=output_shape_spec,
-        multicoil=multicoil,
-        contrast=contrast,
-    )
-    kspace, mask, *_others = next(ds.preprocessed_ds.as_numpy_iterator())
-    np.testing.assert_equal(kspace.shape[-3:], kspace_shape[1:])
-    np.testing.assert_equal(mask.shape[-2:], [1, kspace_shape[-2]])
+    tfio_version_flag = tuple(int(v) for v in tfio.__version__.split('.')) <= (1, 5, 0)
+    with ExitStack() as stack:
+        if tfio_version_flag:
+            stack.enter_context(pytest.raises(ValueError))
+        ds = CartesianFastMRIDatasetBuilder(
+            dataset='test',
+            path=path,
+            mask_mode=mask_mode,
+            output_shape_spec=output_shape_spec,
+            brain=output_shape_spec,
+            multicoil=multicoil,
+            contrast=contrast,
+        )
+    if not tfio_version_flag:
+        kspace, mask, *_others = next(ds.preprocessed_ds.as_numpy_iterator())
+        np.testing.assert_equal(kspace.shape[-3:], kspace_shape[1:])
+        np.testing.assert_equal(mask.shape[-2:], [1, kspace_shape[-2]])

--- a/tf_fastmri_data/tests/datasets/cartesian_test.py
+++ b/tf_fastmri_data/tests/datasets/cartesian_test.py
@@ -20,6 +20,7 @@ def test_cartesian_dataset_train(create_full_fastmri_test_tmp_dataset, mask_mode
     ds = CartesianFastMRIDatasetBuilder(
         path=path,
         mask_mode=mask_mode,
+        brain=output_shape_spec,
         output_shape_spec=output_shape_spec,
         multicoil=multicoil,
         contrast=contrast,

--- a/tf_fastmri_data/tests/datasets/cartesian_test.py
+++ b/tf_fastmri_data/tests/datasets/cartesian_test.py
@@ -46,6 +46,7 @@ def test_cartesian_dataset_test(create_full_fastmri_test_tmp_dataset, mask_mode,
         path=path,
         mask_mode=mask_mode,
         output_shape_spec=output_shape_spec,
+        brain=output_shape_spec,
         multicoil=multicoil,
         contrast=contrast,
     )

--- a/tf_fastmri_data/tests/datasets/cartesian_test.py
+++ b/tf_fastmri_data/tests/datasets/cartesian_test.py
@@ -44,7 +44,7 @@ def test_cartesian_dataset_test(create_full_fastmri_test_tmp_dataset, mask_mode,
         path = create_full_fastmri_test_tmp_dataset['fastmri_tmp_multicoil_test']
     else:
         path = create_full_fastmri_test_tmp_dataset['fastmri_tmp_singlecoil_test']
-    tfio_version_flag = tuple(int(v) for v in tfio.__version__.split('.')) <= (1, 5, 0)
+    tfio_version_flag = tuple(int(v) for v in tfio.__version__.split('.')) <= (0, 15, 0)
     with ExitStack() as stack:
         if tfio_version_flag:
             stack.enter_context(pytest.raises(ValueError))

--- a/tf_fastmri_data/tests/datasets/noisy_test.py
+++ b/tf_fastmri_data/tests/datasets/noisy_test.py
@@ -51,11 +51,12 @@ def test_complex_noisy_dataset_train(create_full_fastmri_test_tmp_dataset, contr
         )
         (image_noisy, *_others), model_outputs = next(ds.preprocessed_ds.as_numpy_iterator())
         if not (batch_size == 2 and slice_random):
-            np.testing.assert_equal(model_outputs.shape[-3:], kspace_shape[1:])
-            np.testing.assert_equal(image_noisy.shape[-3:], kspace_shape[1:])
+            # NOTE: for now complex images can only be of size 320 x 320
+            np.testing.assert_equal(model_outputs.shape[-3:], (320, 320, 1))
+            np.testing.assert_equal(image_noisy.shape[-3:], (320, 320, 1))
         else:
-            assert model_outputs.shape[-2] == 372
-            assert image_noisy.shape[-2] == 372
+            assert model_outputs.shape[-2] == 320
+            assert image_noisy.shape[-2] == 320
         np.testing.assert_equal(image_noisy.ndim, 4)
         assert image_noisy.dtype == np.complex64
         np.testing.assert_equal(model_outputs.ndim, 4)


### PR DESCRIPTION
Getting rid of the use of `tf.py_function` allows us to use multiprocessing (see https://www.tensorflow.org/api_docs/python/tf/data/Dataset#map).

We have to get the metadata (contrast, acceleration, output shape) with pure python, but this is cheap enough to be loaded beforehand.

Small problem related to this [tfio limitation](https://github.com/tensorflow/io/issues/1144).

A small benchmark reveals that this leads to a 4-fold acceleration of the singlecoil cartesian dataset on a 40-core machine.