### PR TITLE
Enhancing fft multicoil

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ FASTMRI_DATA_DIR=/path/to/fastmri python benchmark.py
 
 Currently the benchmark gives the following output:
 ```
-Multi coil with tfio loading (random slice): 0.4548630166053772s per-file.
-Single coil with tfio loading (random slice): 0.01658494710922241s per-file.
+Multi coil with tfio loading (random slice): 0.369743709564209s per-file.
+Single coil with tfio loading (random slice): 0.02855397939682007s per-file.
 Multi coil with h5py loading (random slice, without preprocessing): 0.010439331208042165s per-file.
 Single coil with h5py loading (random slice, without preprocessing): 0.0015996736497735258s per-file.
 Single coil training with tfio loading: 0.04578723907470703s per-step.

--- a/tf_fastmri_data/preprocessing_utils/extract_smaps.py
+++ b/tf_fastmri_data/preprocessing_utils/extract_smaps.py
@@ -1,4 +1,5 @@
 from math import pi
+import multiprocessing
 
 import tensorflow as tf
 from tensorflow.python.ops.signal.fft_ops import ifft2d, ifftshift, fftshift
@@ -44,7 +45,7 @@ def extract_smaps(kspace, low_freq_percentage=8):
     batched_coil_image_low_freq_shifted = tf.map_fn(
         ifft2d,
         batched_kspace,
-        parallel_iterations=10,
+        parallel_iterations=multiprocessing.cpu_count(),
     )
     coil_image_low_freq_shifted = tf.reshape(
         batched_coil_image_low_freq_shifted,

--- a/tf_fastmri_data/preprocessing_utils/extract_smaps.py
+++ b/tf_fastmri_data/preprocessing_utils/extract_smaps.py
@@ -1,8 +1,8 @@
 from math import pi
-import multiprocessing
 
 import tensorflow as tf
-from tensorflow.python.ops.signal.fft_ops import ifft2d, ifftshift, fftshift
+
+from tf_fastmri_data.preprocessing_utils.fourier.cartesian import ortho_ifft2d
 
 
 @tf.function
@@ -25,8 +25,6 @@ def extract_smaps(kspace, low_freq_percentage=8):
         tf.Tensor: extracted raw sensitivity maps.
     """
     k_shape = tf.shape(kspace)[-2:]
-    n_slices = tf.shape(kspace)[0]
-    n_coils = tf.shape(kspace)[1]
     n_low_freq = tf.cast(k_shape * low_freq_percentage / 100, tf.int32)
     center_dimension = tf.cast(k_shape / 2, tf.int32)
     low_freq_lower_locations = center_dimension - tf.cast(n_low_freq / 2, tf.int32)
@@ -40,18 +38,7 @@ def extract_smaps(kspace, low_freq_percentage=8):
     low_freq_mask = tf.transpose(tf.logical_and(X_mask, Y_mask))[None, None, :]
     ###
     low_freq_kspace = kspace * tf.cast(low_freq_mask, kspace.dtype)
-    shifted_kspace = ifftshift(low_freq_kspace, axes=[2, 3])
-    batched_kspace = tf.reshape(shifted_kspace, (-1, k_shape[0], k_shape[1]))
-    batched_coil_image_low_freq_shifted = tf.map_fn(
-        ifft2d,
-        batched_kspace,
-        parallel_iterations=multiprocessing.cpu_count(),
-    )
-    coil_image_low_freq_shifted = tf.reshape(
-        batched_coil_image_low_freq_shifted,
-        (n_slices, n_coils, k_shape[0], k_shape[1]),
-    )
-    coil_image_low_freq = fftshift(coil_image_low_freq_shifted, axes=[2, 3])
+    coil_image_low_freq = ortho_ifft2d(low_freq_kspace)
     # no need to norm this since they all have the same norm
     low_freq_rss = tf.norm(coil_image_low_freq, axis=1)
     coil_smap = coil_image_low_freq / low_freq_rss[:, None]

--- a/tf_fastmri_data/preprocessing_utils/fourier/cartesian.py
+++ b/tf_fastmri_data/preprocessing_utils/fourier/cartesian.py
@@ -22,9 +22,9 @@ def ortho_ifft2d(kspace):
     )
     if len(kspace.shape) == 4:
         # multicoil case
-        image_shape = [n_slices, k_shape_x, k_shape_y]
-    else:
         image_shape = [n_slices, ncoils, k_shape_x, k_shape_y]
+    else:
+        image_shape = [n_slices, k_shape_x, k_shape_y]
     shifted_image = tf.reshape(batched_shifted_image, image_shape)
     image = fftshift(shifted_image, axes=axes)
     return scaling_norm * image

--- a/tf_fastmri_data/preprocessing_utils/fourier/cartesian.py
+++ b/tf_fastmri_data/preprocessing_utils/fourier/cartesian.py
@@ -23,8 +23,10 @@ def ortho_ifft2d(kspace):
     if len(kspace.shape) == 4:
         # multicoil case
         image_shape = [n_slices, ncoils, k_shape_x, k_shape_y]
-    else:
+    elif len(kspace.shape) == 3:
         image_shape = [n_slices, k_shape_x, k_shape_y]
+    else:
+        image_shape = [k_shape_x, k_shape_y]
     shifted_image = tf.reshape(batched_shifted_image, image_shape)
     image = fftshift(shifted_image, axes=axes)
     return scaling_norm * image

--- a/tf_fastmri_data/preprocessing_utils/fourier/cartesian.py
+++ b/tf_fastmri_data/preprocessing_utils/fourier/cartesian.py
@@ -1,3 +1,5 @@
+import multiprocessing
+
 import tensorflow as tf
 from tensorflow.python.ops.signal.fft_ops import ifft2d, ifftshift, fftshift
 
@@ -5,4 +7,24 @@ from tensorflow.python.ops.signal.fft_ops import ifft2d, ifftshift, fftshift
 def ortho_ifft2d(kspace):
     axes = [len(kspace.shape) - 2, len(kspace.shape) - 1]
     scaling_norm = tf.cast(tf.math.sqrt(tf.cast(tf.math.reduce_prod(tf.shape(kspace)[-2:]), 'float32')), kspace.dtype)
-    return scaling_norm * fftshift(ifft2d(ifftshift(kspace, axes=axes)), axes=axes)
+    if len(kspace.shape) == 4:
+        # multicoil case
+        ncoils = tf.shape(kspace)[1]
+    n_slices = tf.shape(kspace)[0]
+    k_shape_x = tf.shape(kspace)[-2]
+    k_shape_y = tf.shape(kspace)[-1]
+    shifted_kspace = ifftshift(kspace, axes=axes)
+    batched_shifted_kspace = tf.reshape(shifted_kspace, (-1, k_shape_x, k_shape_y))
+    batched_shifted_image = tf.map_fn(
+        ifft2d,
+        batched_shifted_kspace,
+        parallel_iterations=multiprocessing.cpu_count(),
+    )
+    if len(kspace.shape) == 4:
+        # multicoil case
+        image_shape = [n_slices, k_shape_x, k_shape_y]
+    else:
+        image_shape = [n_slices, ncoils, k_shape_x, k_shape_y]
+    shifted_image = tf.reshape(batched_shifted_image, image_shape)
+    image = fftshift(shifted_image, axes=axes)
+    return scaling_norm * image


### PR DESCRIPTION
This is related to the tip of [this comment](https://github.com/tensorflow/tensorflow/issues/6541#issuecomment-712151597).

The smaps extraction is speed up by a factor of 25 for full volume multicoil data.
The translation of that on the benchmark is not directly visible since prefetching is used by tensorflow datasets.