### PR TITLE
Add fft2d

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('requirements.txt') as open_file:
 
 setuptools.setup(
     name="tf-fastmri-data",
-    version="0.2.0",
+    version="0.0.3",
     author="Zaccharie Ramzi",
     author_email="zaccharie.ramzi@gmail.com",
     description="Data pipelines for the fastMRI dataset in TensorFlow.",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('requirements.txt') as open_file:
 
 setuptools.setup(
     name="tf-fastmri-data",
-    version="0.0.2",
+    version="0.2.0",
     author="Zaccharie Ramzi",
     author_email="zaccharie.ramzi@gmail.com",
     description="Data pipelines for the fastMRI dataset in TensorFlow.",

--- a/tf_fastmri_data/preprocessing_utils/fourier/cartesian.py
+++ b/tf_fastmri_data/preprocessing_utils/fourier/cartesian.py
@@ -1,7 +1,7 @@
 import multiprocessing
 
 import tensorflow as tf
-from tensorflow.python.ops.signal.fft_ops import ifft2d, ifftshift, fftshift
+from tensorflow.python.ops.signal.fft_ops import ifft2d, ifftshift, fftshift, fft2d
 
 
 def ortho_ifft2d(kspace):
@@ -30,3 +30,32 @@ def ortho_ifft2d(kspace):
     shifted_image = tf.reshape(batched_shifted_image, image_shape)
     image = fftshift(shifted_image, axes=axes)
     return scaling_norm * image
+
+
+def ortho_fft2d(image):
+    image = tf.cast(image, 'complex64')
+    axes = [len(image.shape) - 2, len(image.shape) - 1]
+    scaling_norm = tf.cast(tf.math.sqrt(tf.cast(tf.math.reduce_prod(tf.shape(image)[-2:]), 'float32')), image.dtype)
+    if len(image.shape) == 4:
+        # multicoil case
+        ncoils = tf.shape(kspace)[1]
+    n_slices = tf.shape(image)[0]
+    k_shape_x = tf.shape(image)[-2]
+    k_shape_y = tf.shape(image)[-1]
+    shifted_image = fftshift(image, axes=axes)
+    batched_shifted_image = tf.reshape(shifted_image, (-1, k_shape_x, k_shape_y))
+    batched_shifted_kspace = tf.map_fn(
+        fft2d,
+        batched_shifted_image,
+        parallel_iterations=multiprocessing.cpu_count(),
+    )
+    if len(image.shape) == 4:
+        # multicoil case
+        kspace_shape = [n_slices, ncoils, k_shape_x, k_shape_y]
+    elif len(image.shape) == 3:
+        kspace_shape = [n_slices, k_shape_x, k_shape_y]
+    else:
+        kspace_shape = [k_shape_x, k_shape_y]
+    shifted_kspace = tf.reshape(batched_shifted_kspace, kspace_shape)
+    kspace = fftshift(shifted_kspace, axes=axes)
+    return scaling_norm * kspace


### PR DESCRIPTION
This is a quick small PR to just add ortho FFT which is later used downstream by joint_optimization_mri, to get kspace from images. The idea here is to reduce burden for making multicoil data to single coil.