### PR TITLE
Add codes for generic case of trajectory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('requirements.txt') as open_file:
 
 setuptools.setup(
     name="tf-fastmri-data",
-    version="0.0.4",
+    version="0.0.5",
     author="Zaccharie Ramzi",
     author_email="zaccharie.ramzi@gmail.com",
     description="Data pipelines for the fastMRI dataset in TensorFlow.",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('requirements.txt') as open_file:
 
 setuptools.setup(
     name="tf-fastmri-data",
-    version="0.0.5",
+    version="0.0.4",
     author="Zaccharie Ramzi",
     author_email="zaccharie.ramzi@gmail.com",
     description="Data pipelines for the fastMRI dataset in TensorFlow.",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('requirements.txt') as open_file:
 
 setuptools.setup(
     name="tf-fastmri-data",
-    version="0.0.3",
+    version="0.0.4",
     author="Zaccharie Ramzi",
     author_email="zaccharie.ramzi@gmail.com",
     description="Data pipelines for the fastMRI dataset in TensorFlow.",

--- a/tf_fastmri_data/datasets/non_cartesian.py
+++ b/tf_fastmri_data/datasets/non_cartesian.py
@@ -13,7 +13,7 @@ from tf_fastmri_data.preprocessing_utils.non_cartesian_trajectories import (
     get_debugging_cartesian_trajectory,
 )
 from tf_fastmri_data.preprocessing_utils.scaling import scale_tensors
-from fastmri_recon.data.utils.crop import adjust_image_size
+from tf_fastmri_data.preprocessing_utils.crop import adjust_image_size
 
 
 IMAGE_SIZE = (640, 400)
@@ -90,7 +90,12 @@ class NonCartesianFastMRIDatasetBuilder(FastMRIDatasetBuilder):
                 traj[0],
             )
         traj = tf.repeat(traj, tf.shape(image)[0], axis=0)
-        orig_image_channels = ortho_ifft2d(kspace)
+        orig_image_channels = adjust_image_size(
+            ortho_ifft2d(kspace),
+            self.image_size,
+            multicoil=self.multicoil,
+        )
+        image = adjust_image_size(image, self.image_size)
         nc_kspace = nufft(self.nufft_obj, orig_image_channels, traj, self.image_size)
         nc_kspace, image = scale_tensors(nc_kspace, image, scale_factor=self.scale_factor)
         image = image[..., None]

--- a/tf_fastmri_data/datasets/non_cartesian.py
+++ b/tf_fastmri_data/datasets/non_cartesian.py
@@ -101,7 +101,8 @@ class NonCartesianFastMRIDatasetBuilder(FastMRIDatasetBuilder):
         if self.crop_image_data:
             image = adjust_image_size(image, self.image_size)
         else:
-            output_shape = tf.shape(image)
+            output_shape = tf.shape(image)[1:][None, :]
+            output_shape = tf.tile(output_shape, [tf.shape(image)[0], 1])
         extra_args = (orig_shape,)
         if self.dcomp:
             dcomp = tf.ones(

--- a/tf_fastmri_data/datasets/non_cartesian.py
+++ b/tf_fastmri_data/datasets/non_cartesian.py
@@ -78,7 +78,6 @@ class NonCartesianFastMRIDatasetBuilder(FastMRIDatasetBuilder):
 
     def preprocessing(self, image, kspace):
         traj = self.generate_trajectory()
-        tf.print(tf.shape(traj))
         interpob = self.nufft_obj._extract_nufft_interpob()
         nufftob_forw = kbnufft_forward(interpob, multiprocessing=True)
         nufftob_back = kbnufft_adjoint(interpob, multiprocessing=True)

--- a/tf_fastmri_data/datasets/non_cartesian.py
+++ b/tf_fastmri_data/datasets/non_cartesian.py
@@ -53,7 +53,7 @@ class NonCartesianFastMRIDatasetBuilder(FastMRIDatasetBuilder):
                 f'acq_type must be spiral, radial or cartesian_debug but is {self.acq_type}'
             )
         if self.acq_type == 'other' and self.traj is None:
-            raise ValueEroor(
+            raise ValueError(
                 f'Please provide a trajectory as input in case `acq_type` is `other`'
             )
 

--- a/tf_fastmri_data/datasets/non_cartesian.py
+++ b/tf_fastmri_data/datasets/non_cartesian.py
@@ -13,6 +13,7 @@ from tf_fastmri_data.preprocessing_utils.non_cartesian_trajectories import (
     get_debugging_cartesian_trajectory,
 )
 from tf_fastmri_data.preprocessing_utils.scaling import scale_tensors
+from fastmri_recon.data.utils.crop import adjust_image_size
 
 
 IMAGE_SIZE = (640, 400)
@@ -89,7 +90,12 @@ class NonCartesianFastMRIDatasetBuilder(FastMRIDatasetBuilder):
                 traj[0],
             )
         traj = tf.repeat(traj, tf.shape(image)[0], axis=0)
-        orig_image_channels = ortho_ifft2d(kspace)
+        orig_image_channels = adjust_image_size(
+            ortho_ifft2d(kspace),
+            self.image_size,
+            multicoil=self.multicoil,
+        )
+        image = adjust_image_size(image, self.image_size)
         nc_kspace = nufft(self.nufft_obj, orig_image_channels, traj, self.image_size)
         nc_kspace, image = scale_tensors(nc_kspace, image, scale_factor=self.scale_factor)
         image = image[..., None]

--- a/tf_fastmri_data/datasets/non_cartesian.py
+++ b/tf_fastmri_data/datasets/non_cartesian.py
@@ -90,13 +90,9 @@ class NonCartesianFastMRIDatasetBuilder(FastMRIDatasetBuilder):
                 traj[0],
             )
         traj = tf.repeat(traj, tf.shape(image)[0], axis=0)
-        orig_image_channels = adjust_image_size(
-            ortho_ifft2d(kspace),
-            self.image_size,
-            multicoil=self.multicoil,
-        )
+        orig_image_channels = ortho_ifft2d(kspace)
         image = adjust_image_size(image, self.image_size)
-        nc_kspace = nufft(self.nufft_obj, orig_image_channels, traj, self.image_size)
+        nc_kspace = nufft(self.nufft_obj, orig_image_channels, traj, self.image_size, multicoil=self.multicoil)
         nc_kspace, image = scale_tensors(nc_kspace, image, scale_factor=self.scale_factor)
         image = image[..., None]
         nc_kspaces_channeled = nc_kspace[..., None]

--- a/tf_fastmri_data/datasets/non_cartesian.py
+++ b/tf_fastmri_data/datasets/non_cartesian.py
@@ -96,7 +96,7 @@ class NonCartesianFastMRIDatasetBuilder(FastMRIDatasetBuilder):
         nc_kspace, image = scale_tensors(nc_kspace, image, scale_factor=self.scale_factor)
         image = image[..., None]
         nc_kspaces_channeled = nc_kspace[..., None]
-        orig_shape = tf.ones([tf.shape(kspace)[0]], dtype=tf.int32) * tf.shape(kspace)[-1]
+        orig_shape = self.image_size
         extra_args = (orig_shape,)
         if self.dcomp:
             dcomp = tf.ones(

--- a/tf_fastmri_data/datasets/non_cartesian.py
+++ b/tf_fastmri_data/datasets/non_cartesian.py
@@ -101,7 +101,7 @@ class NonCartesianFastMRIDatasetBuilder(FastMRIDatasetBuilder):
         if self.crop_image_data:
             image = adjust_image_size(image, self.image_size)
         else:
-            output_shape = image.shape
+            output_shape = tf.shape(image)
         extra_args = (orig_shape,)
         if self.dcomp:
             dcomp = tf.ones(

--- a/tf_fastmri_data/datasets/non_cartesian.py
+++ b/tf_fastmri_data/datasets/non_cartesian.py
@@ -97,7 +97,7 @@ class NonCartesianFastMRIDatasetBuilder(FastMRIDatasetBuilder):
         nc_kspace, image = scale_tensors(nc_kspace, image, scale_factor=self.scale_factor)
         image = image[..., None]
         nc_kspaces_channeled = nc_kspace[..., None]
-        orig_shape = tf.ones([tf.shape(kspace)[0]], dtype=tf.int32) * tf.shape(self.image_size)[-1]
+        orig_shape = tf.ones([tf.shape(kspace)[0]], dtype=tf.int32) * self.image_size[-1]
         if self.crop_image_data:
             image = adjust_image_size(image, self.image_size)
         else:

--- a/tf_fastmri_data/datasets/non_cartesian.py
+++ b/tf_fastmri_data/datasets/non_cartesian.py
@@ -90,12 +90,7 @@ class NonCartesianFastMRIDatasetBuilder(FastMRIDatasetBuilder):
                 traj[0],
             )
         traj = tf.repeat(traj, tf.shape(image)[0], axis=0)
-        orig_image_channels = adjust_image_size(
-            ortho_ifft2d(kspace),
-            self.image_size,
-            multicoil=self.multicoil,
-        )
-        image = adjust_image_size(image, self.image_size)
+        orig_image_channels = ortho_ifft2d(kspace)
         nc_kspace = nufft(self.nufft_obj, orig_image_channels, traj, self.image_size)
         nc_kspace, image = scale_tensors(nc_kspace, image, scale_factor=self.scale_factor)
         image = image[..., None]

--- a/tf_fastmri_data/datasets/non_cartesian.py
+++ b/tf_fastmri_data/datasets/non_cartesian.py
@@ -24,12 +24,12 @@ class NonCartesianFastMRIDatasetBuilder(FastMRIDatasetBuilder):
             acq_type='radial',
             dcomp=True,
             scale_factor=1e6,
-            trajectory=None,
+            traj=None,
             **kwargs,
         ):
         self.image_size = image_size
         self.acq_type = acq_type
-        self.traj = trajectory
+        self.traj = traj
         self._check_acq_type()
         self.dcomp = dcomp
         self.scale_factor = scale_factor

--- a/tf_fastmri_data/preprocessing_utils/crop.py
+++ b/tf_fastmri_data/preprocessing_utils/crop.py
@@ -1,0 +1,35 @@
+import tensorflow as tf
+
+
+def crop_center(img, cropx, cropy=None):
+    # taken from https://stackoverflow.com/questions/39382412/crop-center-portion-of-a-numpy-image/39382475
+    if cropy is None:
+        cropy = cropx
+    y, x = img.shape[-2:]
+    startx = x//2 - (cropx//2)
+    starty = y//2 - (cropy//2)
+    return img[..., starty:starty+cropy, startx:startx+cropx]
+
+def adjust_image_size(image, target_image_size, multicoil=False):
+    height = tf.shape(image)[-2]
+    width = tf.shape(image)[-1]
+    n_slices = tf.shape(image)[0]
+    transpose_axis = [1, 2, 0] if not multicoil else [2, 3, 0, 1]
+    transposed_image = tf.transpose(image, transpose_axis)
+    reshaped_image = tf.reshape(transposed_image, [height, width, -1])  # 3D tensors accepted
+    # with channels dimension last
+    target_height = target_image_size[0]
+    target_width = target_image_size[1]
+    padded_image = tf.image.resize_with_crop_or_pad(
+        reshaped_image,
+        target_height,
+        target_width,
+    )
+    if multicoil:
+        final_shape = [target_height, target_width, n_slices, -1]
+    else:
+        final_shape = [target_height, target_width, n_slices]
+    reshaped_padded_image = tf.reshape(padded_image, final_shape)
+    transpose_axis = [2, 0, 1] if not multicoil else [2, 3, 0, 1]
+    transpose_padded_image = tf.transpose(reshaped_padded_image, transpose_axis)
+    return transpose_padded_image

--- a/tf_fastmri_data/preprocessing_utils/extract_smaps.py
+++ b/tf_fastmri_data/preprocessing_utils/extract_smaps.py
@@ -3,6 +3,7 @@ from math import pi
 import tensorflow as tf
 
 from tf_fastmri_data.preprocessing_utils.fourier.cartesian import ortho_ifft2d
+from .crop import adjust_image_size
 
 
 @tf.function
@@ -48,10 +49,6 @@ def extract_smaps(kspace, low_freq_percentage=8):
 
 
 def non_cartesian_extract_smaps(kspace, trajs, dcomp, nufft_back, shape, low_freq_percentage=8):
-    def _crop_for_pad(image, shape, im_size):
-        to_pad = im_size[-1] - shape[0]
-        cropped_image = image[..., to_pad//2:-to_pad//2]
-        return cropped_image
     cutoff_freq = low_freq_percentage / 200 * tf.constant(pi)
     # Get the boolean mask for low frequency
     low_freq_bool_mask = tf.math.reduce_all(tf.math.less_equal(tf.abs(trajs[0]), cutoff_freq), axis=0)
@@ -60,11 +57,7 @@ def non_cartesian_extract_smaps(kspace, trajs, dcomp, nufft_back, shape, low_fre
     low_freq_kspace = tf.boolean_mask(kspace, low_freq_bool_mask, axis=2)
     low_freq_dcomp = tf.boolean_mask(dcomp, low_freq_bool_mask, axis=1)
     coil_smap = nufft_back(low_freq_kspace * tf.cast(low_freq_dcomp, kspace.dtype), low_freq_traj)
-    coil_smap = tf.cond(
-            tf.math.greater_equal(shape, coil_smap.shape[-1]),
-            lambda: coil_smap,
-            lambda: _crop_for_pad(coil_smap, shape, coil_smap.shape),
-        )
+    coil_smap = adjust_image_size(coil_smap, shape, multicoil=True)
     low_freq_rss = tf.norm(coil_smap, axis=1)
     coil_smap = coil_smap / low_freq_rss
     return coil_smap

--- a/tf_fastmri_data/preprocessing_utils/fourier/non_cartesian.py
+++ b/tf_fastmri_data/preprocessing_utils/fourier/non_cartesian.py
@@ -9,7 +9,7 @@ def nufft(nufft_ob, image, ktraj, image_size=None, multicoil=True):
         image = adjust_image_size(
             image,
             image_size,
-            multicoil=self.multicoil,
+            multicoil=multicoil,
         )
     forward_op = kbnufft_forward(nufft_ob._extract_nufft_interpob(), multiprocessing=True)
     shape = tf.shape(image)[-1]

--- a/tf_fastmri_data/preprocessing_utils/fourier/non_cartesian.py
+++ b/tf_fastmri_data/preprocessing_utils/fourier/non_cartesian.py
@@ -26,13 +26,5 @@ def _crop_for_nufft(image, im_size):
 def nufft(nufft_ob, image, ktraj, image_size=None):
     forward_op = kbnufft_forward(nufft_ob._extract_nufft_interpob(), multiprocessing=True)
     shape = tf.shape(image)[-1]
-    if image_size is not None:
-        image_adapted = tf.cond(
-            tf.math.greater(shape, image_size[-1]),
-            lambda: _crop_for_nufft(image, image_size),
-            lambda: _pad_for_nufft(image, image_size),
-        )
-    else:
-        image_adapted = image
-    kspace = forward_op(image_adapted, ktraj)
+    kspace = forward_op(image, ktraj)
     return kspace

--- a/tf_fastmri_data/preprocessing_utils/fourier/non_cartesian.py
+++ b/tf_fastmri_data/preprocessing_utils/fourier/non_cartesian.py
@@ -1,29 +1,16 @@
 import tensorflow as tf
 from tfkbnufft import kbnufft_forward
 
-
-def _pad_for_nufft(image, im_size):
-    shape = tf.shape(image)[-1]
-    to_pad = im_size[-1] - shape
-    padded_image = tf.pad(
-        image,
-        [
-            (0, 0),
-            (0, 0),
-            (0, 0),
-            (to_pad//2, to_pad//2)
-        ]
-    )
-    return padded_image
+from ..crop import adjust_image_size
 
 
-def _crop_for_nufft(image, im_size):
-    shape = tf.shape(image)[-1]
-    to_crop = shape - im_size[-1]
-    cropped_image = image[..., to_crop//2:-to_crop//2]
-    return cropped_image
-
-def nufft(nufft_ob, image, ktraj, image_size=None):
+def nufft(nufft_ob, image, ktraj, image_size=None, multicoil=True):
+    if image_size is not None:
+        image = adjust_image_size(
+            image,
+            image_size,
+            multicoil=self.multicoil,
+        )
     forward_op = kbnufft_forward(nufft_ob._extract_nufft_interpob(), multiprocessing=True)
     shape = tf.shape(image)[-1]
     kspace = forward_op(image, ktraj)

--- a/tf_fastmri_data/tests/datasets/non_cartesian_test.py
+++ b/tf_fastmri_data/tests/datasets/non_cartesian_test.py
@@ -1,0 +1,53 @@
+import numpy as np
+import pytest
+
+from tf_fastmri_data.datasets.non_cartesian import NonCartesianFastMRIDatasetBuilder
+
+
+
+@pytest.mark.parametrize('acq_type', ['radial', 'cartesian', 'spiral'])
+@pytest.mark.parametrize('dcomp', [True, False])
+@pytest.mark.parametrize('multicoil', [True, False])
+@pytest.mark.parametrize('slice_random', [True, False])
+@pytest.mark.parametrize('crop_image_data', [True, False])
+@pytest.mark.parametrize('image_size', [(320, 320), (384, 384)])
+def test_non_cartesian_dataset_train(create_full_fastmri_test_tmp_dataset, acq_type, dcomp, multicoil, slice_random, crop_image_data, image_size):
+    if multicoil:
+        path = create_full_fastmri_test_tmp_dataset['fastmri_tmp_multicoil_train']
+    else:
+        path = create_full_fastmri_test_tmp_dataset['fastmri_tmp_singlecoil_train']
+    ds = NonCartesianFastMRIDatasetBuilder(
+        path=path,
+        acq_type=acq_type,
+        dcomp=dcomp,
+        crop_image_data=crop_image_data,
+        multicoil=multicoil,
+        slice_random=slice_random,
+        image_size=image_size,
+    )
+    (kspace, traj, *_others), image = next(ds.preprocessed_ds.as_numpy_iterator())
+    # CHeck that the kspace and trajectory match in shape!
+    np.testing.assert_equal(kspace.shape[-2], traj.shape[-1])
+    if multicoil:
+        if crop_image_data:
+            smaps, output_shape, op_args = _others
+            np.testing.assert_equal(output_shape[0], image.shape[-3:])
+        else:
+            smaps, op_args = _others
+        # Check the size of smaps
+        np.testing.assert_equal(smaps.shape[-3:-2], kspace.shape[-3:-2])
+        np.testing.assert_equal(smaps.shape[-2:], image_size)
+    else:
+        if crop_image_data:
+            output_shape, op_args = _others
+            np.testing.assert_equal(output_shape[0], image.shape[-3:])
+        else:
+            op_args = _others
+    if dcomp:
+        orig_shape, dcomp = op_args
+        np.testing.assert_equal(dcomp.shape[-1], traj.shape[-1])
+    else:
+        orig_shape = op_args
+    np.testing.assert_equal(orig_shape[0], image_size[-1])
+    np.testing.assert_equal(image.shape[-3:], [320, 320, 1])
+    np.testing.assert_equal(image.ndim, 4)


### PR DESCRIPTION
This PR Handles allowing for undersampling with a given trajectory.
An extension to this, which can be worked on but isnt done here, is to have a large number of such trajectories and later choose randomly for different data