### PR TITLE
Update the test_utils to be compatible with pytest>5 (latest version of pytest)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest==5.0.0 pyxb
+        pip install pytest pyxb
         pip install .
     - name: Test with pytest
       run: pytest -s tf_fastmri_data/tests

--- a/tf_fastmri_data/test_utils.py
+++ b/tf_fastmri_data/test_utils.py
@@ -95,15 +95,9 @@ def create_full_fastmri_tmp_dataset(tmpdir_factory, n_files=2):
         numbered=False,
     )
     #### single coil
-    fastmri_tmp_singlecoil_train = tmpdir_factory.mktemp(str(
-        fastmri_tmp_data_dir.join('singlecoil_train')
-    ), numbered=False)
-    fastmri_tmp_singlecoil_val = tmpdir_factory.mktemp(str(
-        fastmri_tmp_data_dir.join('singlecoil_val')
-    ), numbered=False)
-    fastmri_tmp_singlecoil_test = tmpdir_factory.mktemp(str(
-        fastmri_tmp_data_dir.join('singlecoil_test')
-    ), numbered=False)
+    fastmri_tmp_singlecoil_train = fastmri_tmp_data_dir.join('singlecoil_train').mkdir()
+    fastmri_tmp_singlecoil_val = fastmri_tmp_data_dir.join('singlecoil_val').mkdir()
+    fastmri_tmp_singlecoil_test = fastmri_tmp_data_dir.join('singlecoil_test').mkdir()
     # train
     for i in range(n_files):
         data_filename = f"train_singlecoil_{i}.h5"
@@ -123,15 +117,9 @@ def create_full_fastmri_tmp_dataset(tmpdir_factory, n_files=2):
         )
         af_single_coil.append(af)
     #### multi coil
-    fastmri_tmp_multicoil_train = tmpdir_factory.mktemp(str(
-        fastmri_tmp_data_dir.join('multicoil_train')
-    ), numbered=False)
-    fastmri_tmp_multicoil_val = tmpdir_factory.mktemp(str(
-        fastmri_tmp_data_dir.join('multicoil_val')
-    ), numbered=False)
-    fastmri_tmp_multicoil_test = tmpdir_factory.mktemp(str(
-        fastmri_tmp_data_dir.join('multicoil_test')
-    ), numbered=False)
+    fastmri_tmp_multicoil_train = fastmri_tmp_data_dir.join('multicoil_train').mkdir()
+    fastmri_tmp_multicoil_val = fastmri_tmp_data_dir.join('multicoil_val').mkdir()
+    fastmri_tmp_multicoil_test = fastmri_tmp_data_dir.join('multicoil_test').mkdir()
     # train
     for i in range(n_files):
         data_filename = f"train_multicoil_{i}.h5"


### PR DESCRIPTION
This will help to use more recent codes of pytest and more recent pytest-xdist for parallely running multiple workers for testing, making it faster!